### PR TITLE
Add support for QQmlExtensionPlugin-based plugins

### DIFF
--- a/src/qpm.io/common/messages/qpm.pb.go
+++ b/src/qpm.io/common/messages/qpm.pb.go
@@ -174,6 +174,8 @@ type Package struct {
 	License      LicenseType         `protobuf:"varint,7,opt,name=license,enum=messages.LicenseType" json:"license,omitempty"`
 	PriFilename  string              `protobuf:"bytes,8,opt,name=pri_filename" json:"pri_filename,omitempty"`
 	Webpage      string              `protobuf:"bytes,10,opt,name=webpage" json:"webpage,omitempty"`
+	Plugins      []*Package_Plugin   `protobuf:"bytes,11,rep,name=plugins" json:"plugins,omitempty"`
+	Headers      []string            `protobuf:"bytes,12,rep,name=headers" json:"headers,omitempty"`
 }
 
 func (m *Package) Reset()         { *m = Package{} }
@@ -197,6 +199,13 @@ func (m *Package) GetRepository() *Package_Repository {
 func (m *Package) GetVersion() *Package_Version {
 	if m != nil {
 		return m.Version
+	}
+	return nil
+}
+
+func (m *Package) GetPlugins() []*Package_Plugin {
+	if m != nil {
+		return m.Plugins
 	}
 	return nil
 }
@@ -228,6 +237,15 @@ type Package_Author struct {
 func (m *Package_Author) Reset()         { *m = Package_Author{} }
 func (m *Package_Author) String() string { return proto.CompactTextString(m) }
 func (*Package_Author) ProtoMessage()    {}
+
+type Package_Plugin struct {
+	Class string `protobuf:"bytes,1,opt,name=class" json:"class,omitempty"`
+	Uri   string `protobuf:"bytes,2,opt,name=uri" json:"uri,omitempty"`
+}
+
+func (m *Package_Plugin) Reset()         { *m = Package_Plugin{} }
+func (m *Package_Plugin) String() string { return proto.CompactTextString(m) }
+func (*Package_Plugin) ProtoMessage()    {}
 
 type Dependency struct {
 	Name       string              `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
@@ -488,6 +506,7 @@ func init() {
 	proto.RegisterType((*Package_Repository)(nil), "messages.Package.Repository")
 	proto.RegisterType((*Package_Version)(nil), "messages.Package.Version")
 	proto.RegisterType((*Package_Author)(nil), "messages.Package.Author")
+	proto.RegisterType((*Package_Plugin)(nil), "messages.Package.Plugin")
 	proto.RegisterType((*Dependency)(nil), "messages.Dependency")
 	proto.RegisterType((*VersionInfo)(nil), "messages.VersionInfo")
 	proto.RegisterType((*SearchResult)(nil), "messages.SearchResult")

--- a/src/qpm.io/common/messages/qpm.proto
+++ b/src/qpm.io/common/messages/qpm.proto
@@ -57,6 +57,11 @@ message Package {
 		string name = 1;
 		string email = 2;
 	}
+	
+	message Plugin {
+		string class = 1;
+		string uri = 2;
+	}
 
 	string name = 1;
 	string description = 2;
@@ -67,6 +72,8 @@ message Package {
 	LicenseType license = 7;
 	string pri_filename = 8;
 	string webpage = 10;
+	repeated Plugin plugins = 11;
+	repeated string headers = 12;
 }
 
 message Dependency {


### PR DESCRIPTION
Add vendor.h with qpm::init(app, engine) that initializes each plugin listed in qpm.json.
Each plugin must be listed with the name of the C++ class and the uri this class expects in registerTypes. Each header needed for these classes must also be listed in qpm.json:

``` json
    "headers": [
      "src/mymoduleplugin.h"
    ],
    "plugins": [
      {"class": "MyModulePlugin", "uri": "MyModule"}
    ]
```

In main.cpp:

``` cpp
#include <QGuiApplication>
#include <QQmlApplicationEngine>

#include <vendor.h>

int main(int argc, char *argv[])
{
    QGuiApplication app(argc, argv);

    QQmlApplicationEngine engine;
    qpm::init(app, engine);
    engine.load(QUrl(QStringLiteral("qrc:/main.qml")));

    return app.exec();
}
```

For readability in the pull request, this commit has excessive whitespace in the vendor.h template. This should be fixed later.

The implementation is similar to the proposal mentioned here:
https://trello.com/c/jvIlnOAM/8-add-some-convenience-code-for-registering-modules

PS: This is my first attempt at coding in Go. Please excuse any lack of proper style :)
