### PR TITLE
Qbs support

### DIFF
--- a/src/qpm.io/common/messages/qpm.pb.go
+++ b/src/qpm.io/common/messages/qpm.pb.go
@@ -174,6 +174,8 @@ type Package struct {
 	License      LicenseType         `protobuf:"varint,7,opt,name=license,enum=messages.LicenseType" json:"license,omitempty"`
 	PriFilename  string              `protobuf:"bytes,8,opt,name=pri_filename" json:"pri_filename,omitempty"`
 	Webpage      string              `protobuf:"bytes,10,opt,name=webpage" json:"webpage,omitempty"`
+	Plugins      []*Package_Plugin   `protobuf:"bytes,11,rep,name=plugins" json:"plugins,omitempty"`
+	Headers      []string            `protobuf:"bytes,12,rep,name=headers" json:"headers,omitempty"`
 }
 
 func (m *Package) Reset()         { *m = Package{} }
@@ -197,6 +199,13 @@ func (m *Package) GetRepository() *Package_Repository {
 func (m *Package) GetVersion() *Package_Version {
 	if m != nil {
 		return m.Version
+	}
+	return nil
+}
+
+func (m *Package) GetPlugins() []*Package_Plugin {
+	if m != nil {
+		return m.Plugins
 	}
 	return nil
 }
@@ -228,6 +237,15 @@ type Package_Author struct {
 func (m *Package_Author) Reset()         { *m = Package_Author{} }
 func (m *Package_Author) String() string { return proto.CompactTextString(m) }
 func (*Package_Author) ProtoMessage()    {}
+
+type Package_Plugin struct {
+	Class string `protobuf:"bytes,1,opt,name=class" json:"class,omitempty"`
+	Uri   string `protobuf:"bytes,2,opt,name=uri" json:"uri,omitempty"`
+}
+
+func (m *Package_Plugin) Reset()         { *m = Package_Plugin{} }
+func (m *Package_Plugin) String() string { return proto.CompactTextString(m) }
+func (*Package_Plugin) ProtoMessage()    {}
 
 type Dependency struct {
 	Name       string              `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
@@ -488,6 +506,7 @@ func init() {
 	proto.RegisterType((*Package_Repository)(nil), "messages.Package.Repository")
 	proto.RegisterType((*Package_Version)(nil), "messages.Package.Version")
 	proto.RegisterType((*Package_Author)(nil), "messages.Package.Author")
+	proto.RegisterType((*Package_Plugin)(nil), "messages.Package.Plugin")
 	proto.RegisterType((*Dependency)(nil), "messages.Dependency")
 	proto.RegisterType((*VersionInfo)(nil), "messages.VersionInfo")
 	proto.RegisterType((*SearchResult)(nil), "messages.SearchResult")

--- a/src/qpm.io/common/messages/qpm.pb.go
+++ b/src/qpm.io/common/messages/qpm.pb.go
@@ -176,6 +176,7 @@ type Package struct {
 	Webpage      string              `protobuf:"bytes,10,opt,name=webpage" json:"webpage,omitempty"`
 	Plugins      []*Package_Plugin   `protobuf:"bytes,11,rep,name=plugins" json:"plugins,omitempty"`
 	Headers      []string            `protobuf:"bytes,12,rep,name=headers" json:"headers,omitempty"`
+	QbsFilename  string              `protobuf:"bytes,13,opt,name=qbs_filename" json:"qbs_filename,omitempty"`
 }
 
 func (m *Package) Reset()         { *m = Package{} }

--- a/src/qpm.io/common/messages/qpm.proto
+++ b/src/qpm.io/common/messages/qpm.proto
@@ -74,6 +74,7 @@ message Package {
 	string webpage = 10;
 	repeated Plugin plugins = 11;
 	repeated string headers = 12;
+	string qbs_filename = 13;
 }
 
 message Dependency {

--- a/src/qpm.io/common/messages/qpm.proto
+++ b/src/qpm.io/common/messages/qpm.proto
@@ -57,6 +57,11 @@ message Package {
 		string name = 1;
 		string email = 2;
 	}
+	
+	message Plugin {
+		string class = 1;
+		string uri = 2;
+	}
 
 	string name = 1;
 	string description = 2;
@@ -67,6 +72,8 @@ message Package {
 	LicenseType license = 7;
 	string pri_filename = 8;
 	string webpage = 10;
+	repeated Plugin plugins = 11;
+	repeated string headers = 12;
 }
 
 message Dependency {

--- a/src/qpm.io/common/package.go
+++ b/src/qpm.io/common/package.go
@@ -227,6 +227,13 @@ func (pw PackageWrapper) PriFile() string {
 	return dotUnderscore(pw.Package.Name) + ".pri"
 }
 
+func (pw PackageWrapper) QbsFile() string {
+	if pw.QbsFilename != "" {
+		return pw.QbsFilename
+	}
+	return dotUnderscore(pw.Package.Name) + ".qbs"
+}
+
 func (pw PackageWrapper) QrcFile() string {
 	return dotUnderscore(pw.Package.Name) + ".qrc"
 }


### PR DESCRIPTION
**NOTE:** This pull request is currently based on pull request #21 for C++ plugin support. They may however be separated if that's desirable.

Upon package installation a vendor.qbs file with a Project Item containing a Product Item named "vendor" is created.
The "vendor" project can then be added as Depends { name: "vendor" } in the client project.
The Product Item named "vendor" depends on all the provided packages.
The qpm.json file should contain a "qbs_filename" property and package.qbs should be similar to the following:

```
import qbs 1.0

Product {
    name: "net.ovilab.SimVis"
    type: "staticlibrary"

    Depends { name: 'cpp' }
    Depends { name: "Qt.core" }

    files: [
        "myfile.h",
        "myfile.cpp"
    }
}
```

Due to technical limitations making it impossible to add a Group Item inside another Group Item, a Product with type: "staticlibrary" is used.
