### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/common/package.go
+++ b/common/package.go
@@ -163,7 +163,7 @@ func (pw PackageWrapper) Save() error {
 	return marshaller.Marshal(file, pw.Package)
 }
 
-// Remove a package from this package's list of dependencies.
+// RemoveDependency removes a package from this package's list of dependencies.
 func (pw *PackageWrapper) RemoveDependency(dep *PackageWrapper) {
 	for i, d := range pw.Dependencies {
 		if packageName(d) == dep.Name {

--- a/qpm/core/utils.go
+++ b/qpm/core/utils.go
@@ -133,7 +133,7 @@ func printRow(screenWidth int, columnSpacing int, columnWidths []int, columns []
 	fmt.Printf("\n")
 }
 
-// Renders the given template using the fields contained in the data parameter and
+// WriteTemplate renders the given template using the fields contained in the data parameter and
 // outputs the result to the given file. If the file already exists, it will be
 // overwritten.
 func WriteTemplate(filename string, tpl *template.Template, data interface{}) error {


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, _but this is automated so feel free to close it and just say "**opt out**" to opt out of future CodeLingo outreach PRs._